### PR TITLE
Add -bang option to :JqplayScratch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ whenever the input buffer or the jq filter buffer are modified similar to
 | Command                   | Description                                                         |
 | ------------------------- | ------------------------------------------------------------------- |
 | `:Jqplay [{args}]`        | Start an interactive session using the current json buffer and the jq options `{args}`.|
-| `:JqplayScratch [{args}]` | Like `:Jqplay` but create a new scratch buffer and use it as input. |
+| `:JqplayScratch [{args}]` | Like `:Jqplay` but creates a new scratch buffer as input.           |
+| `:JqplayScratch! [{args}]`| Like `:JqplayScratch` but forces `--null-input` and doesn't pass any input to `jq`.|
 | `:Jqrun [{args}]`         | Invoke jq manually with the jq options `{args}`.                    |
 | `:JqplayClose`            | Stop the _jqplay_ session.                                          |
 | `:JqplayClose!`           | Stop the _jqplay_ session and delete all associated scratch buffers.|
@@ -34,19 +35,22 @@ Running `:Jqplay {args}` on the current json buffer opens two new windows:
 2. The second window displays the `jq` output (prefixed with `jq-output://`).
 
 `{args}` can be any `jq` command-line arguments as you would write them in the
-shell (except for the `-f` and `--from-file` options and the filter).
+shell (except for the `-f/--from-file` option and the filter).
 
-Jq will run automatically whenever the json input buffer or the `jq` filter
-buffer are modified. By default `jq` is invoked when the `InsertLeave` or
-`TextChanged` events are triggered. See `:help jqplay-config` or
-[configuration](#configuration) below on how to change the list of events.
+Jq will run automatically whenever the input buffer or the `jq` filter buffer
+are modified. By default `jq` is invoked when the `InsertLeave` or `TextChanged`
+events are triggered. See [configuration](#configuration) below on how to change
+the list of events.
 
 **Note:** `:Jqplay` can be run only on json buffers, unless the
 `-n/--null-input` and/or `-R/--raw-input` options have been passed.
 
 If you want to start a _jqplay_ session with a new input buffer, run
 `:JqplayScratch`. The command will open an interactive session in a new tab page
-using a new scratch buffer as input.
+using a new scratch buffer as input. Running `:JqplayScratch!` with a bang will
+force the `-n/--null-input` option and open an interactive session without using
+any source buffer. This is useful when you don't need any input to be passed to
+`jq`.
 
 ### Run jq manually on demand
 
@@ -77,13 +81,9 @@ any time with `:Jqstop`.
 
 ## Configuration
 
-Options are set in either the buffer-local dictionary `b:jqplay`, or the
-global dictionary `g:jqplay`.
-
-**Note:** The buffer-variable `b:jqplay` needs to be specified for `json`
-filetypes, for example, in `after/ftplugin/json.vim`
-
-The following entries can be set:
+Options are set in either the buffer-local dictionary `b:jqplay` (specified for
+`json` filetypes), or the global dictionary `g:jqplay`. The following entries
+can be set:
 
 | Key        | Description                 | Default                          |
 | ---------- | --------------------------- | -------------------------------- |
@@ -93,8 +93,6 @@ The following entries can be set:
 
 If you don't want to run `jq` interactively on every buffer change, set
 `autocmds` to an empty list and run `:Jqrun` manually.
-
-See `:help jqplay-config` for more details.
 
 
 ## Examples

--- a/autoload/jqplay.vim
+++ b/autoload/jqplay.vim
@@ -115,6 +115,10 @@ function! jqplay#scratch(bang, mods, args)
     let raw_input = a:args =~# '-\a*R\a*\>\|--raw-input\>' ? 1 : 0
     let null_input = a:args =~# '-\a*n\a*\>\|--null-input\>' ? 1 : 0
 
+    if a:bang && raw_input && null_input
+        return s:error('jqplay: not possible to run :JqplayScratch! with -n and -R')
+    endif
+
     if !s:jqplay_open && !a:bang
         tabnew
         setlocal buflisted buftype=nofile bufhidden=hide noswapfile

--- a/doc/jqplay.txt
+++ b/doc/jqplay.txt
@@ -82,12 +82,15 @@ Commands ~
             job will be terminated. See |job_stop()| for more details on the
             {how} values.
 
-:JqplayScratch [{args}]                                *jqplay-:JqplayScratch*
+:JqplayScratch[!] [{args}]                             *jqplay-:JqplayScratch*
             Like |jqplay-:Jqplay| but start an interactive session in a new
-            |tab| page with a new scratch buffer as input for jq.
+            |tab| page using a new scratch buffer as input for jq.
 
             The scratch buffer is always passed to jq as stdin, even when the
             -n/--null-input options have been specified in {args}.
+
+            Adding [!] will create an interactive session without any input
+            buffer and force the --null-input option.
 
 Functions ~
 

--- a/plugin/jqplay.vim
+++ b/plugin/jqplay.vim
@@ -15,8 +15,8 @@ let g:loaded_jqplay = 1
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
-command! -nargs=? -complete=customlist,jqplay#complete Jqplay call jqplay#start(<q-mods>, <q-args>)
-command! -nargs=? -complete=customlist,jqplay#complete JqplayScratch call jqplay#scratch(<q-mods>, <q-args>)
+command! -nargs=? -complete=customlist,jqplay#complete Jqplay call jqplay#start(<q-mods>, <q-args>, bufnr('%'))
+command! -bang -nargs=? -complete=customlist,jqplay#complete JqplayScratch call jqplay#scratch(<bang>0, <q-mods>, <q-args>)
 
 let &cpoptions = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
Running `:JqplayScratch!` with a bang will open an interactive session
in a new tab page and force the `--null-input` option, but without opening
an input buffer (internally `/dev/null` is passed to `jq` as stdin).
This means that `jq` filters like `inputs` won't work.

`:JqplayScratch!` and `:JqplayScratch! -n` are identical, the `-n` can
be omitted.

Current implementation is quite messy and needs to be rewritten.