### PR TITLE
Avoid autocommands when opening new scratch buffer

### DIFF
--- a/autoload/jqplay.vim
+++ b/autoload/jqplay.vim
@@ -66,7 +66,7 @@ def New_scratch(bufname: string, filetype: string, clean: bool, mods: string, op
             silent execute mods 'sbuffer' bufnr
         endif
     else
-        silent execute mods 'new' fnameescape(bufname)
+        noautocmd silent execute mods 'new' fnameescape(bufname)
         setlocal noswapfile buflisted buftype=nofile bufhidden=hide
         bufnr = bufnr()
         setbufvar(bufnr, '&filetype', filetype)


### PR DESCRIPTION
The first time I tried to start the plugin, it hung forever, I thought it was just a large file, but later, I saw that the folders `jg-output:` and `jq-filter:` were created. 

Arguably, the problem is on my side -- I have a bunch of autocommands that do stuff like if a directory doesn't exist, create it. I'm not entirely sure how these interact to produce this specific outcome, but adding `noautocmd` before the execution of the `new` command seems to avoid any issues, and I think would be safe to add.